### PR TITLE
Replaced cout with cerr to not pollute stdout

### DIFF
--- a/mains/otmain-malicious.cpp
+++ b/mains/otmain-malicious.cpp
@@ -46,7 +46,7 @@ BOOL Connect()
 	int nconnections = m_nNumOTThreads+1;
 
 #ifndef BATCH
-	cout << "Connecting to party "<< !m_nPID << ": " << m_nAddr << ", " << m_nPort << endl;
+	cerr << "Connecting to party "<< !m_nPID << ": " << m_nAddr << ", " << m_nPort << endl;
 #endif
 	for(int k = nconnections-1; k >= 0 ; k--)
 	{
@@ -63,11 +63,11 @@ BOOL Connect()
 				// send pid when connected
 				m_vSockets[k].Send( &k, sizeof(int) );
 		#ifndef BATCH
-				cout << " (" << !m_nPID << ") (" << k << ") connected" << endl;
+				cerr << " (" << !m_nPID << ") (" << k << ") connected" << endl;
 		#endif
 				if(k == 0) 
 				{
-					//cout << "connected" << endl;
+					//cerr << "connected" << endl;
 					return TRUE;
 				}
 				else
@@ -85,7 +85,7 @@ BOOL Connect()
 server_not_available:
 	printf("Server not available: ");
 connect_failure:
-	cout << " (" << !m_nPID << ") connection failed" << endl;
+	cerr << " (" << !m_nPID << ") connection failed" << endl;
 	return FALSE;
 }
 
@@ -94,7 +94,7 @@ connect_failure:
 BOOL Listen()
 {
 #ifndef BATCH
-	cout << "Listening: " << m_nAddr << ":" << m_nPort << ", with size: " << m_nNumOTThreads << endl;
+	cerr << "Listening: " << m_nAddr << ":" << m_nPort << ", with size: " << m_nNumOTThreads << endl;
 #endif
 	int nconnections = m_nNumOTThreads+1;
 
@@ -110,7 +110,7 @@ BOOL Listen()
 	for( int i = 0; i<nconnections; i++ ) //twice the actual number, due to double sockets for OT
 	{
 		CSocket sock;
-		//cout << "New round! " << endl;
+		//cerr << "New round! " << endl;
 		if( !m_vSockets[0].Accept(sock) )
 		{
 			cerr << "Error in accept" << endl;
@@ -128,7 +128,7 @@ BOOL Listen()
 		}
 
 	#ifndef BATCH
-		cout <<  " (" << m_nPID <<") (" << threadID << ") connection accepted" << endl;
+		cerr <<  " (" << m_nPID <<") (" << threadID << ") connection accepted" << endl;
 	#endif
 		// locate the socket appropriately
 		m_vSockets[threadID].AttachFrom(sock);
@@ -136,12 +136,12 @@ BOOL Listen()
 	}
 
 #ifndef BATCH
-	cout << "Listening finished"  << endl;
+	cerr << "Listening finished"  << endl;
 #endif
 	return TRUE;
 
 listen_failure:
-	cout << "Listen failed" << endl;
+	cerr << "Listen failed" << endl;
 	return FALSE;
 }
 
@@ -179,7 +179,7 @@ void InitOTSender(const char* address, int port, int nbaseots, int numOTs)
 #ifdef OTTiming
 	gettimeofday(&np_end, NULL);
 #ifdef BATCH
-	cout << getMillies(np_begin, np_end) << "\t";
+	cerr << getMillies(np_begin, np_end) << "\t";
 #else
 	printf("Time for performing the NP base-OTs: %f ms\n", getMillies(np_begin, np_end));
 #endif
@@ -196,14 +196,14 @@ void InitOTSender(const char* address, int port, int nbaseots, int numOTs)
 
 	assert(nblocks <= NUMOTBLOCKS);
 
-	//cout << "Initializing OT extension receiver " << endl;
+	//cerr << "Initializing OT extension receiver " << endl;
 	//perform the 2nd OT extension step to obtain the base-OTs for the next step
 	receiver = new Mal_OTExtensionReceiver(nSndVals, m_sSecLvl.symbits, m_vSockets.data(), vKeySeedMtx, m_aSeed, nbaseots, s2ots);
 
 	receiver->receive(s2ots, AES_KEY_BITS, U, seedcbitvec, R_OT, 1, mskfct);
 
 	for(int i = 0; i < s2ots; i++) {
-		//cout << i << ": " << (hex) << ((uint64_t*) (vKeySeeds +  i * AES_KEY_BYTES))[0] << ((uint64_t*)(vKeySeeds + i * AES_KEY_BYTES))[1] << (dec) << endl;
+		//cerr << i << ": " << (hex) << ((uint64_t*) (vKeySeeds +  i * AES_KEY_BYTES))[0] << ((uint64_t*)(vKeySeeds + i * AES_KEY_BYTES))[1] << (dec) << endl;
 		URev.SetBit(i, U.GetBitNoMask(i));
 	}
 	//URev.PrintBinary();
@@ -211,7 +211,7 @@ void InitOTSender(const char* address, int port, int nbaseots, int numOTs)
 #ifdef OTTiming
 	gettimeofday(&s2_end, NULL);
 #ifdef BATCH
-	cout << getMillies(s2_begin, s2_end) << "\t";
+	cerr << getMillies(s2_begin, s2_end) << "\t";
 #else
 	printf("Time for performing the 2nd-step base-OTs: %f ms\n", getMillies(s2_begin, s2_end));
 #endif
@@ -224,7 +224,7 @@ void InitOTReceiver(const char* address, int port, int nbaseots, int numOTs)
 	int wdsize = 1 << (CEIL_LOG2(nbaseots));
 	int nblocks = CEIL_DIVIDE(numOTs, NUMOTBLOCKS * wdsize);
 	int s2ots = nblocks * nbaseots;
-	//cout << "nblocks = " << nblocks <<", baseots = " << nbaseots << ", s2ots: " << s2ots << endl;
+	//cerr << "nblocks = " << nblocks <<", baseots = " << nbaseots << ", s2ots: " << s2ots << endl;
 
 #ifdef OTTiming
 	timeval np_begin, np_end, s2_begin, s2_end;
@@ -250,7 +250,7 @@ void InitOTReceiver(const char* address, int port, int nbaseots, int numOTs)
 #ifdef OTTiming
 	gettimeofday(&np_end, NULL);
 #ifdef BATCH
-	cout << getMillies(np_begin, np_end) << "\t";
+	cerr << getMillies(np_begin, np_end) << "\t";
 #else
 	printf("Time for performing the NP base-OTs: %f ms\n", getMillies(np_begin, np_end));
 #endif
@@ -275,7 +275,7 @@ void InitOTReceiver(const char* address, int port, int nbaseots, int numOTs)
 #ifdef OTTiming
 	gettimeofday(&s2_end, NULL);
 #ifdef BATCH
-	cout << getMillies(s2_begin, s2_end) << "\t";
+	cerr << getMillies(s2_begin, s2_end) << "\t";
 #else
 	printf("Time for performing the 2nd-step base-OTs: %f ms\n", getMillies(s2_begin, s2_end));
 #endif
@@ -347,7 +347,7 @@ BOOL ObliviouslySend(CBitVector& X1, CBitVector& X2, int numOTs, int bitlength, 
 #ifdef OTTiming
 	gettimeofday(&ot_end, NULL);
 #ifdef BATCH
-	cout << getMillies(ot_begin, ot_end) + rndgentime << "\t";
+	cerr << getMillies(ot_begin, ot_end) + rndgentime << "\t";
 #else
 	printf("Sender: time for OT extension %f ms\n", getMillies(ot_begin, ot_end) + rndgentime);
 #endif
@@ -369,7 +369,7 @@ BOOL ObliviouslyReceive(CBitVector& choices, CBitVector& ret, int numOTs, int bi
 #ifdef OTTiming
 	gettimeofday(&ot_end, NULL);
 #ifdef BATCH
-	cout << getMillies(ot_begin, ot_end) + rndgentime << "\t";
+	cerr << getMillies(ot_begin, ot_end) + rndgentime << "\t";
 #else
 	printf("Receiver: time for OT extension %f ms\n", getMillies(ot_begin, ot_end) + rndgentime);
 #endif
@@ -386,20 +386,20 @@ int main(int argc, char** argv)
 
 	if(argc < 3)
 	{
-		cout<< "Call as: ./mal_ot.exe role numOTs bitlen baseOTs checks ip-server" << endl;
-		cout << "role: [0/1], 0 = server, 1 = client" << endl;
-		cout << "numOTs: [int] Number of OTs" << endl;
-		cout << "bitlen: [int] Bit-Length of the transferred strings (default:128)" << endl;
-		cout << "baseOTs: [int] number of baseOTs (default 190)" << endl;
-		cout << "checks: [int] number of checks (default 380)" << endl;
-		cout << "ip-server: [char*] (default 127.0.0.1)" << endl;
+		cerr<< "Call as: ./mal_ot.exe role numOTs bitlen baseOTs checks ip-server" << endl;
+		cerr << "role: [0/1], 0 = server, 1 = client" << endl;
+		cerr << "numOTs: [int] Number of OTs" << endl;
+		cerr << "bitlen: [int] Bit-Length of the transferred strings (default:128)" << endl;
+		cerr << "baseOTs: [int] number of baseOTs (default 190)" << endl;
+		cerr << "checks: [int] number of checks (default 380)" << endl;
+		cerr << "ip-server: [char*] (default 127.0.0.1)" << endl;
 		return 0;
 	}
 
 	//Determines whether the program is executed in the sender or receiver role
 	m_nPID = atoi(argv[1]);
 #ifndef BATCH
-	cout << "Playing as role: " << m_nPID << endl;
+	cerr << "Playing as role: " << m_nPID << endl;
 #endif
 	//the number of OTs that are performed. Has to be initialized to a certain minimum size due to
 	int numOTs = 10000000;
@@ -456,7 +456,7 @@ int main(int argc, char** argv)
 
 
 #ifndef BATCH
-		cout << "Sender performing " << numOTs << " OT extensions on " << bitlength << " bit elements" << endl;
+		cerr << "Sender performing " << numOTs << " OT extensions on " << bitlength << " bit elements" << endl;
 #endif
 		ObliviouslySend(X1, X2, numOTs, bitlength, version);
 	}
@@ -473,7 +473,7 @@ int main(int argc, char** argv)
 
 
 #ifndef BATCH
-		cout << "Receiver performing " << numOTs << " OT extensions on " << bitlength << " bit elements" << endl;
+		cerr << "Receiver performing " << numOTs << " OT extensions on " << bitlength << " bit elements" << endl;
 #endif
 		ObliviouslyReceive(choices, response, numOTs, bitlength, version);
 	}
@@ -481,7 +481,7 @@ int main(int argc, char** argv)
 #ifdef OTTiming
 	gettimeofday(&total_end, NULL);
 #ifdef BATCH
-	cout << getMillies(total_begin, total_end) << endl;
+	cerr << getMillies(total_begin, total_end) << endl;
 #else
 	printf("Time for performing the overall evaluation: %f ms\n", getMillies(total_begin, total_end));
 #endif

--- a/ot/baseOT.h
+++ b/ot/baseOT.h
@@ -58,11 +58,11 @@ protected:
 			MPC_HASH_UPDATE(&sha, (BYTE*) &ctr, sizeof(int));
 			MPC_HASH_FINAL(&sha, ret);
 
-			/*cout << "i = " << ctr << ": " << (hex);
+			/*cerr << "i = " << ctr << ": " << (hex);
 			for(int i = 0; i < SHA1_BYTES; i++) {
-				cout << (unsigned int) ret[i];
+				cerr << (unsigned int) ret[i];
 			}
-			cout << (dec) << endl;*/
+			cerr << (dec) << endl;*/
 		}
 
 

--- a/ot/naor-pinkas.cpp
+++ b/ot/naor-pinkas.cpp
@@ -52,7 +52,7 @@ BOOL NaorPinkas::Receiver(int nSndVals, int nOTs, CBitVector& choices,
 		} else {
 			FieldElementSet(PK0, PK_sigma[k]);//PK0 = PK_sigma[k];
 		}
-		//cout << "PK0: " << PK0 << ", PK_sigma: " << PK_sigma[k] << ", choice: " << choice << ", pC[choice: " << pC[choice] << endl;
+		//cerr << "PK0: " << PK0 << ", PK_sigma: " << PK_sigma[k] << ", choice: " << choice << ", pC[choice: " << pC[choice] << endl;
 		FieldElementToByte(pBufIdx, m_fParams.elebytelen, PK0);
 		pBufIdx += m_fParams.elebytelen;
 	}

--- a/ot/ot-extension-malicious.cpp
+++ b/ot/ot-extension-malicious.cpp
@@ -71,13 +71,13 @@ BOOL Mal_OTExtensionReceiver::receive(int numThreads)
 
 BOOL Mal_OTExtensionReceiver::OTReceiverRoutine(int id, int myNumOTs)
 {
-	//cout << "Thread " << id << " started" << endl;
+	//cerr << "Thread " << id << " started" << endl;
 	int myStartPos = id * myNumOTs;
 	int i = myStartPos, nProgress = myStartPos;
 	int RoundWindow = 2;
 	int roundctr = 0;
 	int wd_size_bits = 1 << (CEIL_LOG2(m_nBaseOTs));
-	//cout << "window size = " << wd_size_bits << endl;
+	//cerr << "window size = " << wd_size_bits << endl;
 
 	myNumOTs = min(myNumOTs + myStartPos, m_nOTs) - myStartPos;
 	int lim = myStartPos+myNumOTs;
@@ -103,7 +103,7 @@ BOOL Mal_OTExtensionReceiver::OTReceiverRoutine(int id, int myNumOTs)
 
 	// The send buffer
 	CBitVector vSnd(m_nBaseOTs * OTsPerIteration);
-	//cout << "vSnd size = " << m_nBaseOTs * OTsPerIteration << "(" << m_nBaseOTs << ", " << OTsPerIteration << ")" << endl;
+	//cerr << "vSnd size = " << m_nBaseOTs * OTsPerIteration << "(" << m_nBaseOTs << ", " << OTsPerIteration << ")" << endl;
 
 	// A temporary buffer that stores the resulting seeds from the hash buffer
 	CBitVector seedbuf(OTwindow*AES_KEY_BITS);// = new CBitVector[RoundWindow];
@@ -139,7 +139,7 @@ BOOL Mal_OTExtensionReceiver::OTReceiverRoutine(int id, int myNumOTs)
  		totalTnsTime += getMillies(tempStart, tempEnd);
  		gettimeofday(&tempStart, NULL);
 #endif
- 		//cout << "offset: " << (AES_KEY_BYTES * (i-nProgress))<< ", i = " << i << ", nprogress = " << nProgress << ", otwindow = " << OTwindow << endl;
+ 		//cerr << "offset: " << (AES_KEY_BYTES * (i-nProgress))<< ", i = " << i << ", nprogress = " << nProgress << ", otwindow = " << OTwindow << endl;
 		HashValues(T, seedbuf, i, min(lim-i, OTsPerIteration));
 #ifdef OTTiming
  		gettimeofday(&tempEnd, NULL);
@@ -179,17 +179,17 @@ BOOL Mal_OTExtensionReceiver::OTReceiverRoutine(int id, int myNumOTs)
 	seedbuf.delCBitVector();
 
 #ifdef OTTiming
-	cout << "Receiver time benchmark for performing " << myNumOTs << " OTs on " << m_nBitLength << " bit strings" << endl;
-	cout << "Time needed for: " << endl;
-	cout << "\t Matrix Generation:\t" << totalMtxTime << " ms" << endl;
-	cout << "\t Sending Matrix:\t" << totalSndTime << " ms" << endl;
-	cout << "\t Transposing Matrix:\t" << totalTnsTime << " ms" << endl;
-	cout << "\t Hashing Matrix:\t" << totalHshTime << " ms" << endl;
-	cout << "\t Receiving Values:\t" << totalRcvTime << " ms" << endl;
-	cout << "\t Checking Consistency:\t" << totalChkTime << " ms" << endl;
+	cerr << "Receiver time benchmark for performing " << myNumOTs << " OTs on " << m_nBitLength << " bit strings" << endl;
+	cerr << "Time needed for: " << endl;
+	cerr << "\t Matrix Generation:\t" << totalMtxTime << " ms" << endl;
+	cerr << "\t Sending Matrix:\t" << totalSndTime << " ms" << endl;
+	cerr << "\t Transposing Matrix:\t" << totalTnsTime << " ms" << endl;
+	cerr << "\t Hashing Matrix:\t" << totalHshTime << " ms" << endl;
+	cerr << "\t Receiving Values:\t" << totalRcvTime << " ms" << endl;
+	cerr << "\t Checking Consistency:\t" << totalChkTime << " ms" << endl;
 #endif
 #ifndef BATCH
-	cout << "Receiver finished successfully" << endl;
+	cerr << "Receiver finished successfully" << endl;
 #endif
 	//sleep(1);
 	return TRUE;
@@ -211,20 +211,20 @@ void Mal_OTExtensionReceiver::BuildMatrices(CBitVector& T, CBitVector& SndBuf, i
 	AES_KEY_CTX* seedptr = m_vKeySeedMtx;
 	//How many blocks have been processed until now
 	int blockoffset = CEIL_DIVIDE(ctr, NUMOTBLOCKS * wd_size_bytes * 8);
-	//cout << "Using block: " << blockoffset << " total = " << (m_nBaseOTs * m_nSndVals * blockoffset) << ", and numblocks = " << numblocks << ", baseOTs = " << m_nBaseOTs << ", m_nSndVals = " << m_nSndVals << endl;
+	//cerr << "Using block: " << blockoffset << " total = " << (m_nBaseOTs * m_nSndVals * blockoffset) << ", and numblocks = " << numblocks << ", baseOTs = " << m_nBaseOTs << ", m_nSndVals = " << m_nSndVals << endl;
 	seedptr += (m_nBaseOTs * m_nSndVals * blockoffset);
 
 	for(int k = 0; k < m_nBaseOTs; k++) 	{
 		for(int b = 0; b < rowbytelen/ AES_BYTES; b++, (*counter)++) {
 			MPC_AES_ENCRYPT(seedptr + 2*k, Tptr, ctr_buf);
 #ifdef DEBUG_MALICIOUS
-			cout << "correct: Tka = " << k << ": " << (hex) << ((uint64_t*) Tptr)[0] << ((uint64_t*) Tptr)[1] << (hex) << endl;
+			cerr << "correct: Tka = " << k << ": " << (hex) << ((uint64_t*) Tptr)[0] << ((uint64_t*) Tptr)[1] << (hex) << endl;
 #endif
 			Tptr+=AES_BYTES;
 
 			MPC_AES_ENCRYPT(seedptr + (2*k) + 1, sndbufptr, ctr_buf);
 #ifdef DEBUG_MALICIOUS
-			cout << "correct: Tkb = " << k << ": " << (hex) << ((uint64_t*) sndbufptr)[0] << ((uint64_t*) sndbufptr)[1] << (hex) << endl;
+			cerr << "correct: Tkb = " << k << ": " << (hex) << ((uint64_t*) sndbufptr)[0] << ((uint64_t*) sndbufptr)[1] << (hex) << endl;
 #endif
 			sndbufptr+=AES_BYTES;
 		}
@@ -263,10 +263,10 @@ void Mal_OTExtensionReceiver::HashValues(CBitVector& T, CBitVector& seedbuf, int
 		}
 
 #ifdef OT_HASH_DEBUG
-			cout << "Hash-In for i = " << i << ": " << (hex);
+			cerr << "Hash-In for i = " << i << ": " << (hex);
 			for(int p = 0; p < hashinbytelen; p++)
-				cout << (unsigned int) Tptr[p];
-			cout << (dec) << ", choice-bit = " << (unsigned int) m_nChoices.GetBitNoMask(i) << endl;
+				cerr << (unsigned int) Tptr[p];
+			cerr << (dec) << ", choice-bit = " << (unsigned int) m_nChoices.GetBitNoMask(i) << endl;
 #endif
 
 #ifdef FIXED_KEY_AES_HASHING
@@ -314,8 +314,8 @@ void Mal_OTExtensionReceiver::ReceiveAndProcess(int numThreads)
 
 	while(progress < m_nOTs)
 	{
-		//cout << "Waiting for block " << endl;
-		//cout << "Processing blockid " << OTid;
+		//cerr << "Waiting for block " << endl;
+		//cerr << "Processing blockid " << OTid;
 		m_vSockets[csockid].Receive((BYTE*) &otid, sizeof(int));
 		m_vSockets[csockid].Receive((BYTE*) &processedOTs, sizeof(int));
 
@@ -325,7 +325,7 @@ void Mal_OTExtensionReceiver::ReceiveAndProcess(int numThreads)
 		m_vSockets[csockid].Receive((BYTE*) &(chk_vals.threadid), sizeof(int));
 		m_vSockets[csockid].Receive((BYTE*) &(chk_vals.nchecks), sizeof(int));
 #ifdef DEBUG_MALICIOUS
-		cout << "Checking otid = " << chk_vals.otid << " of len " << processedOTs << " for thread "
+		cerr << "Checking otid = " << chk_vals.otid << " of len " << processedOTs << " for thread "
 				<< chk_vals.threadid << " and doing " << chk_vals.nchecks << " checks" << endl;
 #endif
 		chk_vals.perm = (linking_t*) malloc(sizeof(linking_t) * chk_vals.nchecks);
@@ -358,11 +358,11 @@ void Mal_OTExtensionReceiver::ReceiveAndProcess(int numThreads)
 #endif
 
 		if(m_bProtocol == G_OT || m_bProtocol == C_OT || m_bProtocol == S_OT) {
-			//cout << " with " << processedOTs << " OTs ";
+			//cerr << " with " << processedOTs << " OTs ";
 			rcvbytes = CEIL_DIVIDE(processedOTs * m_nBitLength, 8);
 			if(m_bProtocol == G_OT)
 				rcvbytes = rcvbytes*m_nSndVals;
-			//cout << "Receiving " << rcvbytes << " bytes" << endl;
+			//cerr << "Receiving " << rcvbytes << " bytes" << endl;
 			rcvbytes = m_vSockets[csockid].Receive(vRcv.GetArr(), rcvbytes);
 
 			m_fMaskFct->UnMask(otid, processedOTs, m_nChoices, m_nRet, vRcv, m_vTempOTMasks, m_bProtocol);
@@ -381,8 +381,8 @@ void Mal_OTExtensionReceiver::ReceiveAndProcess(int numThreads)
 	}
 
 #ifdef OTTiming
-	cout << "Total time spent processing received data: " << totalUnmaskTime << " ms" << endl;
-	cout << "Total time spent ensuring malicious security: " << totalCheckTime << " ms" << endl;
+	cerr << "Total time spent processing received data: " << totalUnmaskTime << " ms" << endl;
+	cerr << "Total time spent ensuring malicious security: " << totalCheckTime << " ms" << endl;
 #endif
 
 	vRcv.delCBitVector();
@@ -409,7 +409,7 @@ void Mal_OTExtensionReceiver::EnqueueSeed(BYTE* T0, BYTE* T1, int ctr, int numbl
 		m_tSeedTail->next = seedstr;
 		m_tSeedTail = seedstr;
 	}
-	//cout << "added seed with blockid = " << ctr << endl;
+	//cerr << "added seed with blockid = " << ctr << endl;
 	m_lSeedLock->Unlock();
 }
 
@@ -436,7 +436,7 @@ void Mal_OTExtensionReceiver::ComputeOWF(rcv_check_t* chk_vals) {//linking_t* pe
 	}
 	//the seeds have to exist
 	assert(seedptr->blockid == chk_vals->otid);// && seedptr->expstrbitlen == PadToMultiple(processedOTs, wd_size_bits));
-	//cout << seedptr->expstrbitlen << ", vs. " << wd_size_bits << endl;
+	//cerr << seedptr->expstrbitlen << ", vs. " << wd_size_bits << endl;
 	//case A) is Head
 	if(seedptr == m_tSeedHead) {
 		m_tSeedHead = m_tSeedHead->next;
@@ -474,7 +474,7 @@ void Mal_OTExtensionReceiver::ComputeOWF(rcv_check_t* chk_vals) {//linking_t* pe
 	int rowbytelen = bufrowbytelen;//CEIL_DIVIDE(processedOTs, 8);
 
 #if CHECK_METHOD == 0
-	//cout << "Checking" << endl;
+	//cerr << "Checking" << endl;
 	//Compute all hashes for the permutations given Ta and Tb
 	for(i = 0; i < chk_vals->nchecks; i++) {
 		ka[0] = T0 + chk_vals->perm[i].ida * bufrowbytelen;
@@ -482,11 +482,11 @@ void Mal_OTExtensionReceiver::ComputeOWF(rcv_check_t* chk_vals) {//linking_t* pe
 
 		kb[0] = T0 + chk_vals->perm[i].idb * bufrowbytelen;
 		kb[1] = T1 + chk_vals->perm[i].idb * bufrowbytelen;
-		//cout << "ida = " << permbits[i].ida <<", idb= " <<  permbits[i].idb << endl;
+		//cerr << "ida = " << permbits[i].ida <<", idb= " <<  permbits[i].idb << endl;
 
 		//XOR all four possibilities
 	#ifdef DEBUG_MALICIOUS
-		cout << i << "-th check: between " << chk_vals->perm[i].ida << ", and " << chk_vals->perm[i].idb << endl;
+		cerr << i << "-th check: between " << chk_vals->perm[i].ida << ", and " << chk_vals->perm[i].idb << endl;
 	#endif
 		for(j = 0; j < RECEIVER_HASHES; j++, outptr+=OWF_BYTES) {
 			kaptr = ka[j>>1];
@@ -502,7 +502,7 @@ void Mal_OTExtensionReceiver::ComputeOWF(rcv_check_t* chk_vals) {//linking_t* pe
 	#endif
 		}
 	#ifdef DEBUG_MALICIOUS
-		cout << endl;
+		cerr << endl;
 	#endif
 	}
 #else
@@ -510,19 +510,19 @@ void Mal_OTExtensionReceiver::ComputeOWF(rcv_check_t* chk_vals) {//linking_t* pe
 	BYTE* receiver_choicebits = m_nChoices.GetArr() + CEIL_DIVIDE(chk_vals->otid, 8);
 	CBitVector tmp;
 	tmp.AttachBuf(tmpbuf, bufrowbytelen*8);
-	//cout << "Choice bits: " << endl;
+	//cerr << "Choice bits: " << endl;
 	//m_nChoices.PrintHex();
-	//cout << "Checking" << endl;
+	//cerr << "Checking" << endl;
 	//Compute all hashes for the permutations given Ta, Tb and the choice bits
 	for(i = 0; i < chk_vals->nchecks; i++, sender_permchoicebits++) {
 		ka[0] = T0 + chk_vals->perm[i].ida * bufrowbytelen;
 		kb[0] = T0 + chk_vals->perm[i].idb * bufrowbytelen;
 
-		//cout << "ida = " << permbits[i].ida <<", idb= " <<  permbits[i].idb << endl;
+		//cerr << "ida = " << permbits[i].ida <<", idb= " <<  permbits[i].idb << endl;
 
 		//XOR all four possibilities
 	#ifdef DEBUG_MALICIOUS
-		cout << (dec) << i << "-th check: between " << chk_vals->perm[i].ida << ", and " << chk_vals->perm[i].idb << endl;
+		cerr << (dec) << i << "-th check: between " << chk_vals->perm[i].ida << ", and " << chk_vals->perm[i].idb << endl;
 	#endif
 		for(j = 0; j < RECEIVER_HASHES; j++, outptr+=OWF_BYTES) {
 			kaptr = ka[0];
@@ -542,12 +542,12 @@ void Mal_OTExtensionReceiver::ComputeOWF(rcv_check_t* chk_vals) {//linking_t* pe
 	#endif
 		}
 	#ifdef DEBUG_MALICIOUS
-		cout << endl;
+		cerr << endl;
 	#endif
 	}
 #endif
 
-	//cout << "Finishing check" << endl;
+	//cerr << "Finishing check" << endl;
 	free(tmpbuf);
 	free(ka);
 	free(kb);
@@ -591,7 +591,7 @@ BOOL Mal_OTExtensionReceiver::verifyOT(int NumOTs)
 			{
 				if(tempXc[k] != tempRet[k])
 				{
-					cout << "Error at position i = " << i << ", k = " << k << ", with X" << (hex) << (unsigned int) m_nChoices.GetBitNoMask(i)
+					cerr << "Error at position i = " << i << ", k = " << k << ", with X" << (hex) << (unsigned int) m_nChoices.GetBitNoMask(i)
 							<< " = " << (unsigned int) tempXc[k] << " and res = " << (unsigned int) tempRet[k] << (dec) << endl;
 					resp = 0x00;
 					sock.Send(&resp, 1);
@@ -609,7 +609,7 @@ BOOL Mal_OTExtensionReceiver::verifyOT(int NumOTs)
 	vRcvX1.delCBitVector();
 
 
-	cout << "OT Verification successful" << endl;
+	cerr << "OT Verification successful" << endl;
 	return true;
 }
 
@@ -723,7 +723,7 @@ BOOL Mal_OTExtensionSender::OTSenderRoutine(int id, int myNumOTs)
 	for(int u = 0; u < m_nSndVals; u++)
 		seedbuf[u].Create(OTsPerIteration* AES_KEY_BITS);
 #ifdef ZDEBUG
-	cout << "seedbuf size = " <<OTsPerIteration * AES_KEY_BITS << endl;
+	cerr << "seedbuf size = " <<OTsPerIteration * AES_KEY_BITS << endl;
 #endif
 	vSnd = new CBitVector[numsndvals];//(CBitVector*) malloc(sizeof(CBitVector) * numsndvals);
 	for(int i = 0; i < numsndvals; i++) 	{
@@ -765,7 +765,7 @@ BOOL Mal_OTExtensionSender::OTSenderRoutine(int id, int myNumOTs)
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 
 #ifdef ZDEBUG
-		cout << "Processing block " << nProgress << " with length: " << OTsPerIteration << ", and limit: " << lim << endl;
+		cerr << "Processing block " << nProgress << " with length: " << OTsPerIteration << ", and limit: " << lim << endl;
 #endif
 
 #ifdef OTTiming
@@ -815,17 +815,17 @@ BOOL Mal_OTExtensionSender::OTSenderRoutine(int id, int myNumOTs)
 	if(numsndvals > 0)	free(vSnd);
 
 #ifdef OTTiming
-	cout << "Sender time benchmark for performing " << myNumOTs << " OTs on " << m_nBitLength << " bit strings" << endl;
-	cout << "Time needed for: " << endl;
-	cout << "\t Matrix Generation:\t" << totalMtxTime << " ms" << endl;
-	cout << "\t Sending Matrix:\t" << totalSndTime << " ms" << endl;
-	cout << "\t Transposing Matrix:\t" << totalTnsTime << " ms" << endl;
-	cout << "\t Hashing Matrix:\t" << totalHshTime << " ms" << endl;
-	cout << "\t Receiving Values:\t" << totalRcvTime << " ms" << endl;
+	cerr << "Sender time benchmark for performing " << myNumOTs << " OTs on " << m_nBitLength << " bit strings" << endl;
+	cerr << "Time needed for: " << endl;
+	cerr << "\t Matrix Generation:\t" << totalMtxTime << " ms" << endl;
+	cerr << "\t Sending Matrix:\t" << totalSndTime << " ms" << endl;
+	cerr << "\t Transposing Matrix:\t" << totalTnsTime << " ms" << endl;
+	cerr << "\t Hashing Matrix:\t" << totalHshTime << " ms" << endl;
+	cerr << "\t Receiving Values:\t" << totalRcvTime << " ms" << endl;
 #endif
 
 #ifndef BATCH
-	cout << "Sender finished successfully" << endl;
+	cerr << "Sender finished successfully" << endl;
 #endif
 	return TRUE;
 }
@@ -840,14 +840,14 @@ void Mal_OTExtensionSender::BuildQMatrix(CBitVector& T, CBitVector& RcvBuf, int 
 	int tempctr = *counter;
 	int wd_size_bytes = 1 << (CEIL_LOG2(m_nBaseOTs) -3);
 	int rowbytelen = wd_size_bytes * numblocks;
-	//cout << "counter =  " << (dec) << tempctr << endl;
+	//cerr << "counter =  " << (dec) << tempctr << endl;
 
 	AES_KEY_CTX* seedptr = m_vKeySeeds;
 	int otid = (*counter) - m_nCounter;
 	//How many blocks have been processed until now
 	int blockoffset = CEIL_DIVIDE(otid, NUMOTBLOCKS * wd_size_bytes * 8);
 	int offset = m_nBaseOTs * blockoffset;
-	//cout << "Using block: " << blockoffset << ", counter = " << *counter << ", wdsize = " << wd_size_bytes*8 << "; ctr = " << m_nCounter << endl;
+	//cerr << "Using block: " << blockoffset << ", counter = " << *counter << ", wdsize = " << wd_size_bytes*8 << "; ctr = " << m_nCounter << endl;
 	seedptr += (offset);
 
 
@@ -855,7 +855,7 @@ void Mal_OTExtensionSender::BuildQMatrix(CBitVector& T, CBitVector& RcvBuf, int 
 		for(int b = 0; b < rowbytelen / AES_BYTES; b++, (*counter)++, Tptr += AES_BYTES) {
 			MPC_AES_ENCRYPT(seedptr + k, Tptr, ctr_buf);
 #ifdef DEBUG_MALICIOUS
-			cout << "k = " << k << ": "<< (hex) << ((uint64_t*) Tptr)[0] << ((uint64_t*) Tptr)[1] << (hex) << endl;
+			cerr << "k = " << k << ": "<< (hex) << ((uint64_t*) Tptr)[0] << ((uint64_t*) Tptr)[1] << (hex) << endl;
 #endif
 
 		}
@@ -895,7 +895,7 @@ void Mal_OTExtensionSender::UpdateCheckBuf(BYTE* tocheckseed, BYTE* tocheckrcv, 
 	//right now the rowbytelen needs to be a multiple of AES_BYTES
 	assert(CEIL_DIVIDE(rowbytelen, OWF_BYTES) * OWF_BYTES == rowbytelen);
 #ifdef DEBUG_MALICIOUS
-	cout << "rowbytelen = " << rowbytelen << endl;
+	cerr << "rowbytelen = " << rowbytelen << endl;
 	m_vU.PrintHex();
 #endif
 
@@ -910,7 +910,7 @@ void Mal_OTExtensionSender::UpdateCheckBuf(BYTE* tocheckseed, BYTE* tocheckrcv, 
 #else
 	for(i = 0; i < m_nChecks; i++, chk_buf_ptr+=OWF_BYTES) {
 	#ifdef DEBUG_MALICIOUS
-		cout << "ca: "  << (unsigned int) m_vU.GetBit(blockoffset * m_nBaseOTs + check_vals->perm[i].ida) <<
+		cerr << "ca: "  << (unsigned int) m_vU.GetBit(blockoffset * m_nBaseOTs + check_vals->perm[i].ida) <<
 				", cb: " << (unsigned int) m_vU.GetBit(blockoffset * m_nBaseOTs + check_vals->perm[i].idb) << endl;
 	#endif
 		memset(tmpbuf, 0, sizeof(BYTE) * rowbytelen);
@@ -935,9 +935,9 @@ void Mal_OTExtensionSender::UpdateCheckBuf(BYTE* tocheckseed, BYTE* tocheckrcv, 
 		}
 
 	#ifdef DEBUG_MALICIOUS
-		cout << "seedA: " <<  (hex) << ((uint64_t*) (tocheckseed + check_vals->perm[i].ida * rowbytelen))[0] << ", rcvA: " << ((uint64_t*) (tocheckrcv + check_vals->perm[i].ida * rowbytelen))[0] << (dec) << endl;
-		cout << "seedB: " <<  (hex) << ((uint64_t*) (tocheckseed + check_vals->perm[i].idb * rowbytelen))[0] << ", rcvB: " << ((uint64_t*) (tocheckrcv + check_vals->perm[i].idb * rowbytelen))[0] << (dec) << endl;
-		cout << "input to owf " <<  (hex) << ((uint64_t*) idatmpbuf)[0] << ", " << ((uint64_t*) idbtmpbuf)[0] << (dec) << endl;
+		cerr << "seedA: " <<  (hex) << ((uint64_t*) (tocheckseed + check_vals->perm[i].ida * rowbytelen))[0] << ", rcvA: " << ((uint64_t*) (tocheckrcv + check_vals->perm[i].ida * rowbytelen))[0] << (dec) << endl;
+		cerr << "seedB: " <<  (hex) << ((uint64_t*) (tocheckseed + check_vals->perm[i].idb * rowbytelen))[0] << ", rcvB: " << ((uint64_t*) (tocheckrcv + check_vals->perm[i].idb * rowbytelen))[0] << (dec) << endl;
+		cerr << "input to owf " <<  (hex) << ((uint64_t*) idatmpbuf)[0] << ", " << ((uint64_t*) idbtmpbuf)[0] << (dec) << endl;
 	#endif
 
 		XORandOWF(idatmpbuf, idbtmpbuf,	rowbytelen, tmpbuf, chk_buf_ptr, hash_buf);
@@ -1021,10 +1021,10 @@ void Mal_OTExtensionSender::MaskInputs(CBitVector& Q, CBitVector* seedbuf, CBitV
 				Q.XORBytes(Utmpptr, j * wd_size_bytes, hashinbytelen);
 
 #ifdef OT_HASH_DEBUG
-			cout << "Hash-In for i = " << i << ", u = " << u << ": " << (hex);
+			cerr << "Hash-In for i = " << i << ", u = " << u << ": " << (hex);
 			for(int p = 0; p < hashinbytelen; p++)
-				cout << (unsigned int) (Q.GetArr() + j * wd_size_bytes)[p];
-			cout << (dec) << endl;
+				cerr << (unsigned int) (Q.GetArr() + j * wd_size_bytes)[p];
+			cerr << (dec) << endl;
 #endif
 
 #ifdef FIXED_KEY_AES_HASHING
@@ -1039,7 +1039,7 @@ void Mal_OTExtensionSender::MaskInputs(CBitVector& Q, CBitVector* seedbuf, CBitV
 			memcpy(sbp[u], hash_buf, AES_KEY_BYTES);
 #endif
 
-			//cout << ((unsigned int) sbp[u][0] & 0x01);
+			//cerr << ((unsigned int) sbp[u][0] & 0x01);
 			sbp[u] += AES_KEY_BYTES;
 
 			if(m_bProtocol == S_OT || m_bProtocol == OCRS_OT)
@@ -1175,7 +1175,7 @@ void Mal_OTExtensionSender::SendBlocks(int numThreads)
 			m_vSockets[csockid].Send((BYTE*) tempBlock->permchoicebits, sizeof(BYTE) * m_nChecks);
 #endif
 #ifdef DEBUG_MALICIOUS
-			cout << "Want to check otid = " << tempBlock->blockid << " of len " << tempBlock->processedOTs << " for thread "
+			cerr << "Want to check otid = " << tempBlock->blockid << " of len " << tempBlock->processedOTs << " for thread "
 					<< tempBlock->threadid << " and doing " << m_nChecks << " checks" << endl;
 #endif
 			//wait for reply and check values
@@ -1191,7 +1191,7 @@ void Mal_OTExtensionSender::SendBlocks(int numThreads)
 				exit(0);
 			} else {
 #ifdef DEBUG_MALICIOUS
-				cout << "Consistency check for block " << tempBlock->blockid << " ok" << endl;
+				cerr << "Consistency check for block " << tempBlock->blockid << " ok" << endl;
 #endif
 			}
 
@@ -1235,7 +1235,7 @@ void Mal_OTExtensionSender::SendBlocks(int numThreads)
 		}
 	}
 #ifdef OTTiming
-	cout << "Total time spent transmitting data: " << totalTnsTime << endl;
+	cerr << "Total time spent transmitting data: " << totalTnsTime << endl;
 #endif
 }
 
@@ -1274,11 +1274,11 @@ BOOL Mal_OTExtensionSender::CheckConsistentReceiveBits(BYTE* rcvhashbuf, OTBlock
 
 			if(seedhashcli != *((uint64_t*) seedbufsrvptr) || rcvhashcli != *((uint64_t*) rcvbufsrvptr)) {
 	#ifdef DEBUG_MALICIOUS
-				cout << "Error in " << i <<"-th consistency check: " << endl;
-				cout << "Receiver seed = " << (hex) << ((uint64_t*) (rcvhashbufptr+((2*ca+cb) * OWF_BYTES)))[0] <<
+				cerr << "Error in " << i <<"-th consistency check: " << endl;
+				cerr << "Receiver seed = " << (hex) << ((uint64_t*) (rcvhashbufptr+((2*ca+cb) * OWF_BYTES)))[0] <<
 						((uint64_t*) (rcvhashbufptr+((2*ca+cb) * OWF_BYTES) + j))[1] << ", my seed: " <<
 						((uint64_t*) seedbufsrvptr)[0] << ((uint64_t*) seedbufsrvptr)[1] << (dec) << endl;
-				cout << "Receiver sndval = " << (hex) << ((uint64_t*) (rcvhashbufptr+((2*(ca^1)+(cb^1)) * OWF_BYTES) + j))[0] <<
+				cerr << "Receiver sndval = " << (hex) << ((uint64_t*) (rcvhashbufptr+((2*(ca^1)+(cb^1)) * OWF_BYTES) + j))[0] <<
 						((uint64_t*) (rcvhashbufptr+((2*(ca^1)+(cb^1)) * OWF_BYTES) + j))[1] << ", my snd val = " <<
 						((uint64_t*) rcvbufsrvptr)[0] << ((uint64_t*) rcvbufsrvptr)[1] << (dec) << endl;
 	#endif
@@ -1294,8 +1294,8 @@ BOOL Mal_OTExtensionSender::CheckConsistentReceiveBits(BYTE* rcvhashbuf, OTBlock
 		for(int j = 0; j < OWF_BYTES /sizeof(uint64_t); j++, rcvbufptr++, chkbufptr++) {
 			if(*rcvbufptr != *chkbufptr) {
 	#ifdef DEBUG_MALICIOUS
-				cout << "Error in " << i <<"-th consistency check: " << endl;
-				cout << "Receiver hash = " << (hex) << *rcvbufptr << ", my hash: " << *chkbufptr << endl;
+				cerr << "Error in " << i <<"-th consistency check: " << endl;
+				cerr << "Receiver hash = " << (hex) << *rcvbufptr << ", my hash: " << *chkbufptr << endl;
 	#endif
 				return FALSE;
 			}
@@ -1320,7 +1320,7 @@ BOOL Mal_OTExtensionSender::verifyOT(int NumOTs)
 		processedOTBlocks = min(NUMOTBLOCKS, CEIL_DIVIDE(NumOTs-i, AES_BITS));
  		OTsPerIteration = min(processedOTBlocks * AES_BITS, NumOTs-i);
  		nSnd = CEIL_DIVIDE(OTsPerIteration * m_nBitLength, 8);
- 		//cout << "copying " << nSnd << " bytes from " << CEIL_DIVIDE(i*m_nBitLength, 8) << ", for i = " << i << endl;
+ 		//cerr << "copying " << nSnd << " bytes from " << CEIL_DIVIDE(i*m_nBitLength, 8) << ", for i = " << i << endl;
  		vSnd.Copy(m_vValues[0].GetArr() + CEIL_DIVIDE(i*m_nBitLength, 8), 0, nSnd);
  		sock.Send(vSnd.GetArr(), nSnd);
  		vSnd.Copy(m_vValues[1].GetArr() + CEIL_DIVIDE(i*m_nBitLength, 8), 0, nSnd);
@@ -1328,12 +1328,12 @@ BOOL Mal_OTExtensionSender::verifyOT(int NumOTs)
 		sock.Receive(&resp, 1);
 		if(resp == 0x00)
 		{
-			cout << "OT verification unsuccessful" << endl;
+			cerr << "OT verification unsuccessful" << endl;
 			return false;
 		}
 	}
 	vSnd.delCBitVector();
-	cout << "OT Verification successful" << endl;
+	cerr << "OT Verification successful" << endl;
 	return true;
 }
 
@@ -1353,10 +1353,10 @@ inline void owf(BYTE* hash_buf, int rowbytelen, BYTE* msg, BYTE* H) {
 	#endif
 	for(i = 0; i < rowbytelen; i+=OWF_BYTES, msgptr+=OWF_BYTES) {
 
-		//cout << "Expanding" << endl;
+		//cerr << "Expanding" << endl;
 		MPC_AES_KEY_EXPAND(aesowfkey, H);
 
-		//cout << "encrypting" << endl;
+		//cerr << "encrypting" << endl;
 		MPC_AES_ENCRYPT(aesowfkey, H, msgptr);
 
 		xor_128_buf(H, H, msgptr);
@@ -1371,8 +1371,8 @@ inline void owf(BYTE* hash_buf, int rowbytelen, BYTE* msg, BYTE* H) {
 #endif
 
 #ifdef DEBUG_MALICIOUS
-	cout << "owf for " << rowbytelen << " bytes of " << (hex) << ((uint64_t*) msg)[0] << ((uint64_t*) msg)[1] << (dec) << " = ";
-	cout <<  (hex) << ((uint64_t*) H)[0] << ((uint64_t*) H)[1] << (dec) << endl;
+	cerr << "owf for " << rowbytelen << " bytes of " << (hex) << ((uint64_t*) msg)[0] << ((uint64_t*) msg)[1] << (dec) << " = ";
+	cerr <<  (hex) << ((uint64_t*) H)[0] << ((uint64_t*) H)[1] << (dec) << endl;
 #endif
 
 }
@@ -1397,7 +1397,7 @@ inline void Mal_OTExtensionSender::genRandomPermutation(linking_t* outperm, int 
 
 		}
 		outperm[i].idb = (int) tmpval;
-		//cout << "Permutation " << i << ": " << outperm[i].ida << " <-> " << outperm[i].idb << endl;
+		//cerr << "Permutation " << i << ": " << outperm[i].ida << " <-> " << outperm[i].idb << endl;
 	}
 
 	rndstring.delCBitVector();

--- a/ot/xormasking.h
+++ b/ot/xormasking.h
@@ -39,7 +39,7 @@ public:
 			int length = processedOTs * m_nBitLength;
 			int bytePos = CEIL_DIVIDE(bitPos, 8);
 
-			//cout << "Performing masking for " << bytePos << " and " << bitPos << " to " << length << "(" << m_nBitLength << ", " << processedOTs << ")"<< endl;
+			//cerr << "Performing masking for " << bytePos << " and " << bitPos << " to " << length << "(" << m_nBitLength << ", " << processedOTs << ")"<< endl;
 			values[1].SetBits(values[0].GetArr() + bytePos, bitPos, length);
 			values[1].XORBits(m_vDelta->GetArr() + bytePos, bitPos, length);
 			snd_buf[1].XORBits(values[1].GetArr() + bytePos, 0, length);
@@ -50,7 +50,7 @@ public:
 			int length = processedOTs * m_nBitLength;
 			int bytePos = CEIL_DIVIDE(bitPos, 8);
 
-			//cout << "Performing masking for " << bytePos << " and " << bitPos << " to " << length << "(" << m_nBitLength << ", " << processedOTs << ")"<< endl;
+			//cerr << "Performing masking for " << bytePos << " and " << bitPos << " to " << length << "(" << m_nBitLength << ", " << processedOTs << ")"<< endl;
 			values[1].SetBits(values[0].GetArr() + bytePos, bitPos, length);
 			values[1].XORBits(m_vDelta->GetArr() + bytePos, bitPos, length);
 			snd_buf[0].XORBits(values[1].GetArr() + bytePos, 0, length);
@@ -64,7 +64,7 @@ public:
 		int length = processedOTs * m_nBitLength;
 		int bytePos = CEIL_DIVIDE(bitPos, 8);
 
-		//cout << "Performing masking for " << bytePos << " and " << bitPos << " to " << length << "(" << m_nBitLength << ", " << processedOTs << ")"<< endl;
+		//cerr << "Performing masking for " << bytePos << " and " << bitPos << " to " << length << "(" << m_nBitLength << ", " << processedOTs << ")"<< endl;
 		values[1].SetBits(values[0].GetArr() + bytePos, bitPos, length);
 		values[1].XORBits(m_vDelta->GetArr() + bytePos, bitPos, length);
 
@@ -119,14 +119,14 @@ public:
 		{
 			for(int i = 0; i< processedOTs; i++, sbp+=AES_KEY_BYTES)
 			{
-			//	cout << "Setting bits from " << (offset + i) * bitlength << " with " << bitlength << " len " << endl;
-				//cout << "Byte: " << ((unsigned int) sbp[0]) << ", bitlenh = " << bitlength << ", pos = " << (offset + i) * bitlength << ", ";
+			//	cerr << "Setting bits from " << (offset + i) * bitlength << " with " << bitlength << " len " << endl;
+				//cerr << "Byte: " << ((unsigned int) sbp[0]) << ", bitlenh = " << bitlength << ", pos = " << (offset + i) * bitlength << ", ";
 
 				out.SetBits(sbp, (offset + i) * bitlength, bitlength);
 				//out.PrintBinary();
 
 			}
-			//cout << "Out = "<< endl;
+			//cerr << "Out = "<< endl;
 			//out.PrintHex();
 		}
 		else
@@ -145,7 +145,7 @@ public:
 					out.SetBits(m_bBuf, (offset+ i) * bitlength + (counter*AES_BITS), AES_BITS);
 				}
 				//the final bits
-				//cout << "bits: " << (counter*AES_BITS) << ", bitlength: " << m_nBitLength << endl;
+				//cerr << "bits: " << (counter*AES_BITS) << ", bitlength: " << m_nBitLength << endl;
 				if((rem = bitlength - (counter*AES_BITS)) > 0)
 				{
 					MPC_AES_ENCRYPT(&tkey, m_bBuf, ctr_buf);

--- a/util/brick.cpp
+++ b/util/brick.cpp
@@ -47,11 +47,11 @@ void FixedPointExp::Init(mpz_t g, mpz_t p, int fieldsize) {
   m_isInitialized = true;
 
 //   for (unsigned u=0; u<m_numberOfElements; ++u) {
-//     cout << "table[" << u << "] = " << m_table[u] << endl;
+//     cerr << "table[" << u << "] = " << m_table[u] << endl;
 //     ZZ res;
 //     ZZ ex = power_ZZ(2,u);
 //     PowerMod(res, m_g, ex, m_p);
-//     cout << "    (Should be = " << res << ")" << endl;
+//     cerr << "    (Should be = " << res << ")" << endl;
 //   }
 }
 

--- a/util/cbitmatrix.h
+++ b/util/cbitmatrix.h
@@ -156,7 +156,7 @@ public:
 			rowaptr = (REGISTER_SIZE*) matrix;
 			rowbptr = rowaptr + destidx;//ptr = temp_mat;
 
-			//cout << "numrounds = " << numrounds << " iterations: " <<endl;
+			//cerr << "numrounds = " << numrounds << " iterations: " <<endl;
 			//Preset the masks that are required for bit-level swapping operations
 
 			mask = TRANSPOSITION_MASKS[i];
@@ -249,9 +249,9 @@ public:
 		{
 			for(int j = 0; j < 128; j++)
 			{
-				cout << !!(matrix[(i*128 + j)/8] & (1<<(j%8)));
+				cerr << !!(matrix[(i*128 + j)/8] & (1<<(j%8)));
 			}
-			cout << endl;
+			cerr << endl;
 		}
 	}
 

--- a/util/cbitvector.cpp
+++ b/util/cbitvector.cpp
@@ -56,7 +56,7 @@ void CBitVector::Create(int bits, BYTE* seed, int& cnt)
 void CBitVector::Create(int bits)
 {
 	if(bits == 0) bits = AES_BITS;
-	//cout << "creating " << bits << " sized vector" << endl;
+	//cerr << "creating " << bits << " sized vector" << endl;
 	//TODO: Uncomment either of them
 	//if( m_pBits ) free(m_pBits);
 	if(m_nSize > 0 ) free(m_pBits);
@@ -154,21 +154,21 @@ void CBitVector::SetBits(BYTE* p, int pos, int len)
 		temp = p[i];
 		m_pBits[posctr] = (m_pBits[posctr] & RESET_BIT_POSITIONS[lowermask]) | ((temp << lowermask) & 0xFF);
 		m_pBits[posctr+1] = (m_pBits[posctr+1] & RESET_BIT_POSITIONS_INV[uppermask]) | (temp >> uppermask);
-		//cout << "Iteration for whole byte done" << endl;
+		//cerr << "Iteration for whole byte done" << endl;
 	}
 	int remlen = len & 0x07;
 	if(remlen)
 	{
 		temp = p[i] & RESET_BIT_POSITIONS[remlen];
-		//cout << "temp = " << (unsigned int) temp << endl;
+		//cerr << "temp = " << (unsigned int) temp << endl;
 		if(remlen <= uppermask)
 		{
-			//cout << "Setting " << remlen  << " lower bits with lowermask = " << lowermask << ", and temp " << (unsigned int) temp << endl;
+			//cerr << "Setting " << remlen  << " lower bits with lowermask = " << lowermask << ", and temp " << (unsigned int) temp << endl;
 			m_pBits[posctr] = (m_pBits[posctr] & (~(((1<<remlen)-1) << lowermask))) | ((temp << lowermask) & 0xFF);
 		}
 		else
 		{
-			//cout << "Setting " << remlen  << " bits with lowermask = " << lowermask << ", uppermask = " << uppermask << ", and temp = " << (unsigned int) temp << endl;
+			//cerr << "Setting " << remlen  << " bits with lowermask = " << lowermask << ", uppermask = " << uppermask << ", and temp = " << (unsigned int) temp << endl;
 			m_pBits[posctr] = (m_pBits[posctr] & RESET_BIT_POSITIONS[lowermask]) | ((temp << lowermask) & 0xFF);
 			m_pBits[posctr+1] = (m_pBits[posctr+1] & (~(((1<<(remlen-uppermask))-1)))) | (temp >> uppermask);
 		}
@@ -225,18 +225,18 @@ void CBitVector::GetBits(BYTE* p, int pos, int len)
 		//temp = p[i] & GET_BIT_POSITIONS[remlen];
 		if(remlen <= uppermask)
 		{
-			//cout << "Getting " << remlen  << " lower bits with lowermask = " << lowermask << ", " << (unsigned int) m_pBits[posctr] << endl;
+			//cerr << "Getting " << remlen  << " lower bits with lowermask = " << lowermask << ", " << (unsigned int) m_pBits[posctr] << endl;
 			p[i] = ((m_pBits[posctr] & (((1<<remlen)-1 << lowermask))) >> lowermask) & 0xFF;
-			//cout << "p[i] = " << (unsigned int) p[i] << endl;
+			//cerr << "p[i] = " << (unsigned int) p[i] << endl;
 		}
 		else
 		{
-			//cout << "Getting upper" << endl;
-			//cout << "Getting " << remlen  << " upper bits with lowermask = " << lowermask << ", " << (unsigned int) m_pBits[posctr] << ", and uppermask = "
+			//cerr << "Getting upper" << endl;
+			//cerr << "Getting " << remlen  << " upper bits with lowermask = " << lowermask << ", " << (unsigned int) m_pBits[posctr] << ", and uppermask = "
 			//		<< uppermask << ", " << (unsigned int) m_pBits[posctr+1] << endl;
 			p[i] = ((m_pBits[posctr] & GET_BIT_POSITIONS[lowermask]) >> lowermask) & 0xFF;
 			p[i] |= (m_pBits[posctr+1] & (((1<<(remlen-uppermask))-1))) << uppermask;
-			//cout << "p[i] = " << (unsigned int) p[i] << endl;
+			//cerr << "p[i] = " << (unsigned int) p[i] << endl;
 		}
 	}
 }
@@ -265,7 +265,7 @@ void CBitVector::XORBits(BYTE* p, int pos, int len)
 {
 	if(len < 1 || (pos+len) > m_nSize << 3)
 	{
-		//cout << "m_nSize = " << m_nSize << ", pos+len = " << (pos + len)/8 << endl;
+		//cerr << "m_nSize = " << m_nSize << ", pos+len = " << (pos + len)/8 << endl;
 		return;
 	}
 	if(len == 1)
@@ -289,21 +289,21 @@ void CBitVector::XORBits(BYTE* p, int pos, int len)
 		temp = p[i];
 		m_pBits[posctr] ^= ((temp << lowermask) & 0xFF);
 		m_pBits[posctr+1] ^= (temp >> uppermask);
-		//cout << "Iteration for whole byte done" << endl;
+		//cerr << "Iteration for whole byte done" << endl;
 	}
 	int remlen = len & 0x07;
 	if(remlen)
 	{
 		temp = p[i] & RESET_BIT_POSITIONS[remlen];
-		//cout << "temp = " << (unsigned int) temp << endl;
+		//cerr << "temp = " << (unsigned int) temp << endl;
 		if(remlen <= uppermask)
 		{
-			//cout << "Setting " << remlen  << " lower bits with lowermask = " << lowermask << ", and temp " << (unsigned int) temp << endl;
+			//cerr << "Setting " << remlen  << " lower bits with lowermask = " << lowermask << ", and temp " << (unsigned int) temp << endl;
 			m_pBits[posctr] ^= ((temp << lowermask) & 0xFF);
 		}
 		else
 		{
-			//cout << "Setting " << remlen  << " bits with lowermask = " << lowermask << ", uppermask = " << uppermask << ", and temp = " << (unsigned int) temp << endl;
+			//cerr << "Setting " << remlen  << " bits with lowermask = " << lowermask << ", uppermask = " << uppermask << ", and temp = " << (unsigned int) temp << endl;
 			m_pBits[posctr] ^= ((temp << lowermask) & 0xFF);
 			m_pBits[posctr+1] ^= (temp >> uppermask);
 		}
@@ -437,34 +437,34 @@ void CBitVector::SetAND(BYTE* p, BYTE* q, int pos, int len)
 void CBitVector:: Print(int fromBit, int toBit) {
 	int to = toBit > (m_nSize << 3)? (m_nSize << 3) : toBit;
 	for (int i = fromBit; i < to; i++)	{
-		cout << (unsigned int) GetBitNoMask(i);
+		cerr << (unsigned int) GetBitNoMask(i);
 	}
-	cout << endl;
+	cerr << endl;
 }
 
 void CBitVector::PrintHex(int fromByte, int toByte) {
 	for (int i = fromByte; i < toByte; i++) {
-		cout << setw(2) << setfill('0') << (hex) << ((unsigned int) m_pBits[i]);
+		cerr << setw(2) << setfill('0') << (hex) << ((unsigned int) m_pBits[i]);
 	}
-	cout << (dec) << endl;
+	cerr << (dec) << endl;
 }
 
 void CBitVector::PrintHex()
 {
 	for (int i = 0; i < m_nSize; i++)
 	{
-		cout << setw(2) << setfill('0') << (hex) << ((unsigned int) m_pBits[i]);
+		cerr << setw(2) << setfill('0') << (hex) << ((unsigned int) m_pBits[i]);
 	}
-	cout << (dec) << endl;
+	cerr << (dec) << endl;
 }
 
 void CBitVector::PrintBinaryMasked(int from, int to)
 {
 	for (int i = from; i < to; i++)
 	{
-		cout << (unsigned int) GetBit(i);
+		cerr << (unsigned int) GetBit(i);
 	}
-	cout << endl;
+	cerr << endl;
 }
 
 void CBitVector::PrintContent()
@@ -478,23 +478,23 @@ void CBitVector::PrintContent()
 	{
 		for(int i = 0; i < m_nNumElements; i++)
 		{
-			cout << Get<int>(i) << ", ";
+			cerr << Get<int>(i) << ", ";
 		}
-		cout << endl;
+		cerr << endl;
 	}
 	else
 	{
 		for(int i = 0; i < m_nNumElements; i++)
 		{
-			cout << "(";
+			cerr << "(";
 			for(int j = 0; j < m_nNumElementsDimB-1; j++)
 			{
-				cout << Get2D<int>(i, j) << ", ";
+				cerr << Get2D<int>(i, j) << ", ";
 			}
-			cout << Get2D<int>(i, m_nNumElementsDimB-1);
-			cout << "), ";
+			cerr << Get2D<int>(i, m_nNumElementsDimB-1);
+			cerr << "), ";
 		}
-		cout << endl;
+		cerr << endl;
 	}
 }
 
@@ -547,17 +547,17 @@ unsigned int CBitVector::GetInt(int bitPos, int bitLen)
 	ret = (m_pBits[i++] >> (j)) & (GetMask(min(8, bitLen)));
 	if (bitLen == 1)
 		return ret;
-	//cout << "MpBits: " << (unsigned int) m_pBits[i-1] << ", ret: " << ret << endl;
+	//cerr << "MpBits: " << (unsigned int) m_pBits[i-1] << ", ret: " << ret << endl;
 	j = 8-j;
 	for(k = bitLen - j; i<(bitPos + bitLen+7)/8-1; i++, j+=8, k-=8)
 	{
 		//ret |= REVERSE_BYTE_ORDER[m_pBits[i+pos]] << (i*8);
 		ret |= m_pBits[i] << j;
-		//cout << "MpBits: " <<(unsigned int) m_pBits[i] << ", ret: " << ret << ", j: " << j << endl;
+		//cerr << "MpBits: " <<(unsigned int) m_pBits[i] << ", ret: " << ret << ", j: " << j << endl;
 		//m_pBits[i+pos] = ( ((REVERSE_NIBBLE_ORDER[(p>>((2*i)*4))&0xF] << 4) | REVERSE_NIBBLE_ORDER[(p>>((2*i+1)*4))&0xF])  & 0xFF);//((p>>((2*i+1)*4))&0xF) | ((p>>((2*i)*4))&0xF) & 0xFF;
 	}
 	ret |= (m_pBits[i] & SELECT_BIT_POSITIONS[k]) << j; //for the last execution 0<=k<=8
-	//cout << "MpBits: " <<(unsigned int) m_pBits[i] << ", ret: " << ret << ", k = " << k <<  ", selects: " << (unsigned int) SELECT_BIT_POSITIONS[k] << ", j: " << j << endl;
+	//cerr << "MpBits: " <<(unsigned int) m_pBits[i] << ", ret: " << ret << ", k = " << k <<  ", selects: " << (unsigned int) SELECT_BIT_POSITIONS[k] << ", j: " << j << endl;
 	return ret;
 }
 
@@ -600,7 +600,7 @@ void CBitVector::EklundhBitTranspose(int rows, int columns)
 		rowaptr = (REGISTER_SIZE*) m_pBits;
 		rowbptr = rowaptr + destidx;//ptr = temp_mat;
 
-		//cout << "numrounds = " << numrounds << " iterations: " << LOG2_REGISTER_SIZE << ", offset = " << offset << ", srcidx = " << srcidx << ", destidx = " << destidx << endl;
+		//cerr << "numrounds = " << numrounds << " iterations: " << LOG2_REGISTER_SIZE << ", offset = " << offset << ", srcidx = " << srcidx << ", destidx = " << destidx << endl;
 		//Preset the masks that are required for bit-level swapping operations
 		mask = TRANSPOSITION_MASKS[i];
 		invmask = ~mask;

--- a/util/crypto.cpp
+++ b/util/crypto.cpp
@@ -238,7 +238,7 @@ BOOL MiraclInit(SECLVL lvl, BYTE* seed, fparams* params) {
 	*(params->eccparams.X) = ecx;
 	*(params->eccparams.Y) = ecy;
 
-	//cout << "params->eccparams.X : " << (*params->eccparams.X) << endl;
+	//cerr << "params->eccparams.X : " << (*params->eccparams.X) << endl;
 
 	//reset the base representation
 	mip->IOBASE = 10;
@@ -347,7 +347,7 @@ void printepoint(epoint point)
 {
 	Big x, y;
 	epoint_getxyz(&point,x.getbig(),y.getbig(),NULL);
-	cout << "(" << x << ", " << y << ")" << endl;
+	cerr << "(" << x << ", " << y << ")" << endl;
 }
 
 

--- a/util/socket.h
+++ b/util/socket.h
@@ -11,7 +11,7 @@ class CSocket
 public:
 	CSocket(){ m_hSock = INVALID_SOCKET; }
 	~CSocket(){ }
-	//~CSocket(){ cout << "Closing Socket!" << endl; Close(); }
+	//~CSocket(){ cerr << "Closing Socket!" << endl; Close(); }
 	
 public:
 	BOOL Socket()
@@ -48,7 +48,7 @@ public:
 		//setsockopt(m_hSock, IPPROTO_TCP, TCP_MAXSEG , (char*)&OptSegSizeLen, OptSegSize);
 		// disable tcp slow start - (false)
 		//setsockopt(m_hSock, IPPROTO_TCP, TM_TCP_SLOW_START , (char*)&bOptVal, bOptLen);
-		//cout << "TCP_MAXSEG: " << TCP_MAXSEG << endl;
+		//cerr << "TCP_MAXSEG: " << TCP_MAXSEG << endl;
 		return success;
 	
 	}
@@ -207,7 +207,7 @@ public:
 
 	int Receive(void* pBuf, int nLen, int nFlags = 0)
 	{
-		//cout << "Receiving " << nLen << " bytes" << endl;
+		//cerr << "Receiving " << nLen << " bytes" << endl;
 		char* p = (char*) pBuf;
 		int n = nLen;
 		int ret = 0;
@@ -249,7 +249,7 @@ public:
  
 	int Send(const void* pBuf, int nLen, int nFlags = 0)
 	{
-		//cout << "Sending " << nLen << " bytes: " << ((unsigned int*)pBuf)[0] << endl;
+		//cerr << "Sending " << nLen << " bytes: " << ((unsigned int*)pBuf)[0] << endl;
 		return send(m_hSock, (char*)pBuf, nLen, nFlags);
 	}	
 	  

--- a/util/timer.h
+++ b/util/timer.h
@@ -46,10 +46,10 @@ static void StartWatch(const string& msg, ABYPHASE phase) {
 			cerr << "Phase not recognized: " << phase << endl;
 			return;
 	}
-	//cout << " m_nTimings, " << m_nTimings <<  ", phase = " << (unsigned int) phase << endl;
+	//cerr << " m_nTimings, " << m_nTimings <<  ", phase = " << (unsigned int) phase << endl;
 	gettimeofday(&(m_tTimes[phase].tbegin), NULL);
 #ifndef BATCH
-	cout << msg << endl;
+	cerr << msg << endl;
 #endif
 }
 
@@ -67,7 +67,7 @@ static void StopWatch(const string& msg, ABYPHASE phase) {
 
 
 #ifndef BATCH
-	cout << msg << m_tTimes[phase].timing << " ms " << endl;
+	cerr << msg << m_tTimes[phase].timing << " ms " << endl;
 #endif
 
 }
@@ -75,16 +75,16 @@ static void StopWatch(const string& msg, ABYPHASE phase) {
 
 static void PrintTimings() {
 	string unit = " ms";
-	cout << "Timings: " << endl;
-	cout << "Total =\t\t" << m_tTimes[0].timing << unit << endl;
-	cout << "Init =\t\t" << m_tTimes[1].timing << unit << endl;
-	cout << "CircuitGen =\t" << m_tTimes[2].timing << unit << endl;
-	cout << "Network =\t" << m_tTimes[3].timing << unit << endl;
-	cout << "BaseOTs =\t" << m_tTimes[4].timing << unit << endl;
-	cout << "Setup =\t\t" << m_tTimes[5].timing << unit << endl;
-	cout << "OTExtension =\t" << m_tTimes[6].timing << unit << endl;
-	cout << "Garbling =\t" << m_tTimes[7].timing << unit << endl;
-	cout << "Online =\t" << m_tTimes[8].timing << unit << endl;
+	cerr << "Timings: " << endl;
+	cerr << "Total =\t\t" << m_tTimes[0].timing << unit << endl;
+	cerr << "Init =\t\t" << m_tTimes[1].timing << unit << endl;
+	cerr << "CircuitGen =\t" << m_tTimes[2].timing << unit << endl;
+	cerr << "Network =\t" << m_tTimes[3].timing << unit << endl;
+	cerr << "BaseOTs =\t" << m_tTimes[4].timing << unit << endl;
+	cerr << "Setup =\t\t" << m_tTimes[5].timing << unit << endl;
+	cerr << "OTExtension =\t" << m_tTimes[6].timing << unit << endl;
+	cerr << "Garbling =\t" << m_tTimes[7].timing << unit << endl;
+	cerr << "Online =\t" << m_tTimes[8].timing << unit << endl;
 }
 
 static double GetTimeForPhase(ABYPHASE phase) {


### PR DESCRIPTION
This allows people to build their applications such that they can
parse the stdout without having to filter debug messages from
this library.